### PR TITLE
add: llama_client.py を .env 対応化

### DIFF
--- a/backend/utils/llama_client.py
+++ b/backend/utils/llama_client.py
@@ -1,0 +1,22 @@
+import os
+import requests
+from dotenv import load_dotenv
+
+# .envファイルを読み込む
+load_dotenv()
+
+# 環境変数から URL を取得（デフォルトURLは空にしておく）
+LLAMA_API_URL = os.getenv("LLAMA_API_URL", "").strip()
+
+if not LLAMA_API_URL:
+    raise RuntimeError("❌ LLAMA_API_URL が .env に設定されていません")
+
+def analyze_text_with_llama(text: str) -> dict:
+    try:
+        response = requests.post(LLAMA_API_URL, json={"text": text}, verify=False)  # verify=Falseは開発用
+        response.raise_for_status()
+        result = response.json()
+        print("🧠 LLaMA構造化結果:", result)  # ログ出力（任意）
+        return result
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"LLaMA構造化API呼び出し失敗: {e}")


### PR DESCRIPTION
## 概要
Colabのngrok URLを毎回コードに書かずに済むよう、.envファイルから読み込むようにしました。

## 変更内容
- llama_client.py を .env 対応に変更
- .env ファイルに LLAMA_API_URL を設定
- requests.post に verify=False を追加（開発用）

## 動作確認
- Colab で ngrok URL を取得して .env に反映
- FastAPI /natural エンドポイントで構造化成功確認

## 備考
- 本番運用時は verify=True に戻す必要あり
- `.env` は `.gitignore` 対象のままでOK
